### PR TITLE
Add support for inserting multiple files into the gulp pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ npm install gulp-file
 Creates a vinyl file with the given `name` from `source` string or buffer and
 returns a transform stream for use in your gulp pipeline.
 
+### plugin(sourceArray, options)
+
+Creates vinyl files for each entry in the array.  Each entry is an object with a `name` and `source` property.  A vinyl file is created with the given `name` and `source` and inserted into the returned transform stream.
+
 ## Example
 
-[Primus][0] outputs the client library as a string. Using `gulp-file` we can
+[Primus](https://github.com/primus/primus) outputs the client library as a string. Using `gulp-file` we can
 create a vinyl file from the string and insert it into the gulp pipeline:
 
 ```javascript
@@ -45,7 +49,8 @@ var gulp = require('gulp')
 gulp.task('js', function() {
   var str = primus.library();
 
-  return file('primus.js', str, { src: true }).pipe(gulp.dest('dist'));
+  return file('primus.js', str, { src: true })
+    .pipe(gulp.dest('dist'));
 });
 ```
 
@@ -57,5 +62,3 @@ Calls `stream.end()` to be used at the beginning of your pipeline in place of
 `gulp.src()`. Default: `false`.
 
 ## BSD Licensed
-
-[0]: https://github.com/primus/primus

--- a/lib/file.js
+++ b/lib/file.js
@@ -11,12 +11,23 @@ var gutil = require('gulp-util')
  * @return {stream.Transform}
  * @api public
  */
-module.exports = function(name, source, options) {
-  var file = new gutil.File({
-    cwd: "",
-    base: "",
-    path: name,
-    contents: ((source instanceof Buffer) ? source : new Buffer(source))
+module.exports = function(fileArray, source, options) {
+  if (fileArray instanceof Array) {
+    options = source;
+  } else {
+    fileArray = [{
+      name: fileArray,
+      source: source
+    }];
+  }
+
+  var vinylFiles = fileArray.map(function(file) {
+    return new gutil.File({
+      cwd: "",
+      base: "",
+      path: file.name,
+      contents: ((file.source instanceof Buffer) ? file.source : new Buffer(file.source))
+    });
   });
 
   var stream = through.obj(function(file, enc, callback) {
@@ -25,7 +36,9 @@ module.exports = function(name, source, options) {
     return callback();
   });
 
-  stream.write(file);
+  vinylFiles.forEach(function(vinylFile) {
+    stream.write(vinylFile);
+  });
 
   if (options && options.src) {
     stream.end();


### PR DESCRIPTION
This PR adds the ability to pass an array of objects describing files to add to the gulp pipeline.  The plugin is still compatible with the previous way of calling it with a single file.