### PR TITLE
refactor remove gulp-util and update tests and dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: node_js
 node_js:
-- '0.10'
+  - 6
+
+script:
+  - npm test

--- a/lib/file.js
+++ b/lib/file.js
@@ -1,4 +1,4 @@
-var gutil = require('gulp-util')
+var Vinyl = require('vinyl')
   , through = require('through2');
 
 /**
@@ -21,23 +21,17 @@ module.exports = function(fileArray, source, options) {
     }];
   }
 
-  var vinylFiles = fileArray.map(function(file) {
-    return new gutil.File({
-      cwd: "",
-      base: "",
-      path: file.name,
-      contents: ((file.source instanceof Buffer) ? file.source : new Buffer(file.source))
-    });
-  });
-
   var stream = through.obj(function(file, enc, callback) {
     this.push(file);
 
     return callback();
   });
 
-  vinylFiles.forEach(function(vinylFile) {
-    stream.write(vinylFile);
+  fileArray.forEach(function(file) {
+    stream.write(new Vinyl({
+      path: file.name,
+      contents: file.source instanceof Buffer ? file.source : new Buffer(file.source)
+    }));
   });
 
   if (options && options.src) {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Create vinyl files from a string or buffer and insert into the Gulp pipeline.",
   "main": "./lib/file.js",
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha test --recursive --reporter spec"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -26,11 +26,11 @@
   "homepage": "https://github.com/alexmingoia/gulp-file",
   "dependencies": {
     "through2": "^0.4.1",
-    "gulp-util": "^2.2.14"
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",
-    "mocha": "^1.18.2",
-    "gulp": "^3.6.2"
+    "gulp": "^3.9.1",
+    "mocha": "^3.4.2"
   }
 }

--- a/test/file.js
+++ b/test/file.js
@@ -28,4 +28,21 @@ describe('plugin', function() {
 
     stream.end();
   });
+
+  it('returns array transform stream', function(done) {
+    var stream = plugin([{name: 'test.js', source: '/* TEST */'}, {name: 'test2.js', source: '/* TEST2 */'}]);
+
+    expect(stream).to.be.an('object');
+    expect(stream._transform).to.be.a('function');
+
+    stream.on('data', function(chunk) {
+      expect(chunk).to.not.be.empty();
+    })
+    .on('end', function() {
+      done();
+    })
+    .emit('data', 'test');
+
+    stream.end();
+  });
 });


### PR DESCRIPTION
Hi,

Since gulp-util has been deprecated, this PR replaces gulp-util with alternative individual modules. https://github.com/gulpjs/gulp-util