### PR TITLE
Drop dependency on deprecated `gulp-util`

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -1,4 +1,4 @@
-var gutil = require('gulp-util')
+var Vinyl = require('vinyl')
   , through = require('through2');
 
 /**
@@ -22,9 +22,9 @@ module.exports = function(fileArray, source, options) {
   }
 
   var vinylFiles = fileArray.map(function(file) {
-    return new gutil.File({
+    return new Vinyl({
       cwd: "",
-      base: "",
+      base: undefined,
       path: file.name,
       contents: ((file.source instanceof Buffer) ? file.source : new Buffer(file.source))
     });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/alexmingoia/gulp-file",
   "dependencies": {
     "through2": "^0.4.1",
-    "gulp-util": "^2.2.14"
+    "vinyl": "^2.1.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
Closes alexmingoia/gulp-file#10